### PR TITLE
Fixes #3: spacing of MathJax equations

### DIFF
--- a/inst/rmarkdown/templates/drposter/skeleton/drposter_files/page.css
+++ b/inst/rmarkdown/templates/drposter/skeleton/drposter_files/page.css
@@ -52,6 +52,18 @@ html {
 	margin-top: 1em;
 }
 
+/* There are a few exceptions to the generic top-margin */
+
 li + li , li > ul, li > ol {
 	margin-top: 0;
 }
+
+/* Exclude mathjax which has custom HTML tags, and doesn't fit with the generic spacing */
+[class^="mjx-"] {
+	margin-top: 0;
+}
+/* Also override the custom margins of "display equations" since they're already governed by an enclosing block of some sort, like a paragraph */
+.MJXc-display {
+	margin: 0 !important;
+}
+


### PR DESCRIPTION
The generic `margin-top` style that adds space between adjacent tags was not working well with MathJax.  From the inspector tool, it seems like my rule was adding a new margin-top for each child element of the equation, hence the large inconsistent spaces around inline or display equations.

@FrankD, can you confirm if this patch fixes the equations in your poster, too?  I'll merge afterwards.