### PR TITLE
Wrap long URLs instead of allowing them to overflow

### DIFF
--- a/inst/rmarkdown/templates/drposter/skeleton/drposter_files/sections.css
+++ b/inst/rmarkdown/templates/drposter/skeleton/drposter_files/sections.css
@@ -71,6 +71,18 @@ img {
 	background-color: white;  /* Eliminate transparency for consistency among all images with non-white backgrounds */
 }
 
+p {
+	max-width: 100%;  /* Prevent paragraphs overflowing the flexbox container */
+}
+
+a {
+	/* Break long URLs into multiple lines.  Alternatively, specify break-all to
+	immediately place the line break instead of first trying to keep it on a newline.
+	This style is currently ignored in Firefox, which already handles URL line breaks.
+	See also https://developer.mozilla.org/en-US/docs/Web/CSS/word-break */
+	word-break: break-word;
+}
+
 .level2 h2, .level2 h3 {
 	flex: 100%;
 }


### PR DESCRIPTION
Fixes #8 

Long URLs were causing `<p>` tags to become wider than their parent flexbox containers.  The styles in this PR ensure that long URLs are placed on a newline to try to get them to fit, then adding line breaks as necessary to prevent overflow.

Testing documentation in a followup comment: