### PR TITLE
Fix duplicate pandoc flags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drposter
 Title: Generate academic posters in R Markdown and CSS
-Version: 0.0.8.9000
+Version: 0.0.8.9100
 Authors@R: person("Ben", "Bucior", email = "bbucior@u.northwestern.edu", role = c("aut", "cre"))
 Description: R Markdown (pandoc) format to generate reproducible posters,
     inspired by 'reveal.js' presentations.

--- a/R/drposter.R
+++ b/R/drposter.R
@@ -118,12 +118,15 @@ drposter_poster <- function(self_contained = FALSE,
       # post-processing hook runs after the PDF hook. (output_format prepends the PDF hook)
     }
     dr_format <- rmarkdown::output_format(
-      # Copy params from the base_format
-      dr_format$knitr,
-      dr_format$pandoc,
+      # rmarkdown::output_format can inherit from a base_format and merge settings
+      # together (such as adding a post_processor step).
+      # Most flags are NULL by default, thus automatically derived from the base_format.
+      # For the others, specify the known values for drposter or use a safe default.
+      rmarkdown::knitr_options(),
+      rmarkdown::pandoc_options(to = "html4"),
       keep_md = dr_format$keep_md,
       clean_supporting = dr_format$clean_supporting,
-      # The other flags are NULL by default, thus automatically derived from the base_format
+      # Inherit args and other settings from the drposter version of html_document above
       base_format = dr_format,
       # Add a PDF post-processing step to the existing format
       post_processor = compile_pdf


### PR DESCRIPTION
Per #15, drposter was not formatting the generated html and pdf output correctly when the export_pdf step was enabled.

The root cause was an inconsistency in the generated args for pandoc. Many of the args were incorrectly duplicated due how the base_format was being called. After cleaning up the calls to rmarkdown, the build commands are now consistent and appear to fix #15.

@ElineVG could you verify if this branch resolves the issues you were seeing as well? Many thanks for your help with reporting and debugging!